### PR TITLE
Ignore the mqtt.generic add-on for now

### DIFF
--- a/prepare-docs.rb
+++ b/prepare-docs.rb
@@ -14,7 +14,7 @@ $esh_repo = "https://github.com/eclipse/smarthome"
 $esh_repo_root = $esh_repo + "/blob/master/docs/documentation"
 $version = nil
 
-$ignore_bindings = ["mqtt"]
+$ignore_bindings = ["mqtt", "mqtt.generic"]
 
 
 if ENV["OH_DOCS_VERSION"] then


### PR DESCRIPTION
The mqtt.generic binding breaks the build since the script assumes add-ons with a "." in their id are a sub-addon of an existing parent add-on (see "bluetooth", "bluetooth.*"), and the mqtt binding is on the ignore list... so put mqtt.generic on it too.

Signed-off-by: Yannick Schaus <github@schaus.net>