### PR TITLE
Remove `--tty` from Docker installation instruction

### DIFF
--- a/.vuepress/components/InstallInstructions.vue
+++ b/.vuepress/components/InstallInstructions.vue
@@ -136,7 +136,6 @@ usermod -a -G openhab myownuser
 <pre class="language-shell"><code>docker run \
         --name openhab \
         --net=host \
-        --tty \
         -v /etc/localtime:/etc/localtime:ro \
         -v /etc/timezone:/etc/timezone:ro \
         -v openhab_addons:/openhab/addons \


### PR DESCRIPTION
Nowadays the container will start in server mode when not allocating a pseudo-TTY.

See: https://github.com/openhab/openhab-docker#startup-modes