### PR TITLE
[RFC] Add New User Guide to Homepage

### DIFF
--- a/.vuepress/components/home/Jumbotron.vue
+++ b/.vuepress/components/home/Jumbotron.vue
@@ -6,7 +6,8 @@
       <div class="white-logo"><ClientOnly><img src="/logo-white.png" class="white-logo" /></ClientOnly></div>
       <h1 class="hero">empowering the smart home</h1>
       <h2 class="lead">a vendor and technology agnostic open source automation software for your home</h2>
-      <router-link to="docs/" class="action-button">Get Started ➜</router-link>
+      <h3> information section for new users here...</h3>
+      <router-link to="docs/" class="action-button">Introduction ➜</router-link>
       <a class="demo-button" target="_blank" href="https://demo.openhab.org">Try It ➜</a>
     </div>
     <div class="phone">


### PR DESCRIPTION
One of the outcomes of 2 very intense discussions [here](https://community.openhab.org/t/openhab-marketing-is-lacking/149280?u=oliver2) and [here](https://community.openhab.org/t/call-to-action-volunteers-for-openhab-marketing/149618?u=oliver2) is the lack of guidance for new user who either have limited technical knowledge or do not want to study several sections in our documentation and will need a lot of time to read through all important pages.
I’d like to add a new section on our homepage (text, graphics) and link to the guide. By intention I do not want to use our documentation for this guide as we do not want to confront new (unexperienced) users with our rich and detailed documentation.
This guide will cover all steps from downloading to creating a first easy rule in a very easy and compressed way with the aim to show how easy it is to get up and running with openHAB.

This opening PR is a RFC where I want to get in contact with you and discuss this before I start putting work in this. Maybe you also have some tips for me how to do the changes here as I am not familiar with Vuepress and editing md files. I will do my best but you probably need to do some layouting stuff to make it look good.
Thanks, Oliver