### PR TITLE
Add InlineImage component

### DIFF
--- a/.vuepress/components/InlineImage.vue
+++ b/.vuepress/components/InlineImage.vue
@@ -1,0 +1,17 @@
+<template>
+  <img :style="{ height: imgHeight, 'vertical-align': imgVerticalAlign }" />
+</template>
+
+<script>
+export default {
+  props: ['height', 'verticalAlign'],
+  computed: {
+    imgHeight () {
+      return this.height ? this.height : '1.5em'
+    },
+    imgVerticalAlign () {
+      return this.verticalAlign ? this.verticalAlign : 'text-bottom'
+    }
+  }
+}
+</script>


### PR DESCRIPTION
I'm not sure if this is the right way, but this is an attempt at adding the `InlineImage` Vue component to the website, needed for https://github.com/openhab/openhab-docs/pull/2518.

@florian-h05 Is this the right way? I didn't quite follow you with "importing from docs during build", but I see that the other Vue components used in the docs also exist here.