### PR TITLE
Support nested add-on docs in the sidebar navigation

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -6,7 +6,7 @@ const AddonsTransformations = require('./addons-transformations.js')
 const AddonsVoice = require('./addons-voice.js')
 const AddonsUserInterface = require('./addons-ui.js')
 
-const fs = require ('fs-extra')
+const fs = require('fs-extra')
 const path = require('path')
 const _ = require('lodash');
 const CopyWebpackPlugin = require('copy-webpack-plugin')
@@ -20,7 +20,7 @@ const DocsSidebarNavigation = require('./openhab-docs/.vuepress/docs-sidebar.js'
 const feedOptions = {
   canonical_base: 'https://openhab.org',
   posts_directories: ['/blog/'],
-  sort: entries => _.reverse( _.sortBy( entries, 'date' ) ),
+  sort: entries => _.reverse(_.sortBy(entries, 'date')),
 }
 
 const noAddons = process.env.OH_NOADDONS
@@ -114,8 +114,8 @@ module.exports = {
   },
   configureWebpack: (config, isServer) => {
     config.plugins.push(new CopyWebpackPlugin([
-      { from: '.vuepress/_redirects', to: '.'},
-      { from: '.vuepress/_headers', to: '.'},
+      { from: '.vuepress/_redirects', to: '.' },
+      { from: '.vuepress/_headers', to: '.' },
     ]))
   },
   serviceWorker: false,
@@ -242,37 +242,37 @@ module.exports = {
         {
           title: 'Bindings',
           collapsible: false,
-          children: AddonsBindings.sort((a,b) => a[1].localeCompare(b[1]))
+          children: AddonsBindings
         },
         {
           title: 'System Integrations',
           collapsible: false,
-          children: AddonsIntegrations.sort((a,b) => a[1].localeCompare(b[1]))
+          children: AddonsIntegrations
         },
         {
           title: 'Automation',
           collapsible: false,
-          children: AddonsAutomation.sort((a,b) => a[1].localeCompare(b[1]))
+          children: AddonsAutomation
         },
         {
           title: 'Data Persistence',
           collapsible: false,
-          children: AddonsPersistence.sort((a,b) => a[1].localeCompare(b[1]))
+          children: AddonsPersistence
         },
         {
           title: 'Data Transformation',
           collapsible: false,
-          children: AddonsTransformations.sort((a,b) => a[1].localeCompare(b[1]))
+          children: AddonsTransformations
         },
         {
           title: 'Voice',
           collapsible: false,
-          children: AddonsVoice.sort((a,b) => a[1].localeCompare(b[1]))
+          children: AddonsVoice
         },
         {
           title: 'User Interface',
           collapsible: false,
-          children: AddonsUserInterface.sort((a,b) => a[1].localeCompare(b[1]))
+          children: AddonsUserInterface
         }
       ]
     }

--- a/scripts/lib/website_utils.rb
+++ b/scripts/lib/website_utils.rb
@@ -58,12 +58,14 @@ def extract_addon_metadata(addon_path, type)
   readme = addon_path / "readme.md"
   return nil unless readme.exist?
 
-  front_matter = extract_front_matter(readme) || {}
+  path = "#{type}/#{addon_path.basename}/"
+
+  front_matter = extract_front_matter(readme)
+  front_matter = {} unless front_matter.is_a?(Hash)
 
   title = front_matter[:label]
-  return nil unless title && !title.include?("1.x")
+  return nil unless title.is_a?(String) && !title.include?("1.x")
 
-  path = "#{type}/#{addon_path.basename}/"
   children = front_matter[:children]
 
   [path, title, children]

--- a/scripts/lib/website_utils.rb
+++ b/scripts/lib/website_utils.rb
@@ -146,6 +146,8 @@ end
 #       title: "Title"
 #
 def normalize_child_path(prefix, item)
+  return if item.nil?
+
   case item
   when Array
     # If it is a flat [path, title] pair, treat it as a single node
@@ -160,7 +162,8 @@ def normalize_child_path(prefix, item)
   when Hash
     process_hash_node(prefix, item)
   else
-    item
+    puts "⚠️  Unknown child node type in #{prefix}: #{item.class} - #{item.inspect}"
+    nil
   end
 end
 

--- a/scripts/lib/website_utils.rb
+++ b/scripts/lib/website_utils.rb
@@ -4,6 +4,8 @@ require "English"
 require "fileutils"
 require "json"
 require "yaml"
+require "uri"
+require "open-uri"
 
 def verbose(message)
   puts message if $verbose
@@ -56,9 +58,9 @@ def extract_addon_metadata(addon_path, type)
   readme = addon_path / "readme.md"
   return nil unless readme.exist?
 
-  front_matter = extract_front_matter(readme)
+  front_matter = extract_front_matter(readme) || {}
 
-  title = front_matter[:label] if front_matter.is_a?(Hash)
+  title = front_matter[:label]
   return nil unless title && !title.include?("1.x")
 
   path = "#{type}/#{addon_path.basename}/"

--- a/scripts/lib/website_utils.rb
+++ b/scripts/lib/website_utils.rb
@@ -76,11 +76,25 @@ def extract_front_matter(pathname)
   begin
     YAML.safe_load(match[:yaml], symbolize_names: true)
   rescue Psych::Exception => e
-    puts "⚠️  YAML parsing error in front-matter of #{pathname} - skipping front-matter extraction: #{e.message}"
-    nil
+    puts "⚠️  YAML parsing error in front-matter of #{pathname}: #{e.message}"
+    label = extract_title(content)
+    if label
+      puts "    Manually parsed label: #{label}"
+    else
+      puts "    Could not find a label in the front-matter of #{pathname}"
+    end
+    { label: }
   end
 rescue Errno::ENOENT
   nil
+end
+
+def extract_title(content)
+  # Find the first line starting with "label: "
+  label_line = content.each_line.find { |line| line.start_with?("label: ") }
+  return nil unless label_line
+
+  label_line.delete_prefix("label: ").strip
 end
 
 def create_addon_entry(path, title, children)

--- a/scripts/lib/website_utils.rb
+++ b/scripts/lib/website_utils.rb
@@ -84,11 +84,13 @@ rescue Errno::ENOENT
 end
 
 def create_addon_entry(path, title, children)
+  children = [children] unless children.is_a?(Array)
+  children = normalize_child_path(path, children).compact
   if children && !children.empty?
     {
       path: "/addons/#{path}",
       title:,
-      children: [[path, "Overview"]] + normalize_child_path(path, children)
+      children: [[path, "Overview"]] + children
     }
   else
     [path, title]
@@ -165,7 +167,10 @@ def process_hash_node(prefix, node)
     updated[:path] = normalized_path
   end
 
-  updated[:children] = normalize_child_path(prefix, updated[:children]).compact if updated[:children]
+  if updated[:children]
+    children_list = updated[:children].is_a?(Array) ? updated[:children] : [updated[:children]]
+    updated[:children] = normalize_child_path(prefix, children_list).compact
+  end
 
   updated
 end

--- a/scripts/lib/website_utils.rb
+++ b/scripts/lib/website_utils.rb
@@ -75,8 +75,8 @@ def extract_front_matter(pathname)
 
   begin
     YAML.safe_load(match[:yaml], symbolize_names: true)
-  rescue Psych::SyntaxError => e
-    puts "⚠️  YAML syntax error in front-matter of #{pathname} - skipping front-matter extraction: #{e.message}"
+  rescue Psych::Exception => e
+    puts "⚠️  YAML parsing error in front-matter of #{pathname} - skipping front-matter extraction: #{e.message}"
     nil
   end
 rescue Errno::ENOENT

--- a/scripts/lib/website_utils.rb
+++ b/scripts/lib/website_utils.rb
@@ -2,6 +2,8 @@
 
 require "English"
 require "fileutils"
+require "json"
+require "yaml"
 
 def verbose(message)
   puts message if $verbose
@@ -48,4 +50,122 @@ def clean_ignored_files(path, dry_run: false)
 rescue Errno::ENOENT, Errno::EACCES => e
   puts "Error accessing #{path}: #{e.message}"
   false
+end
+
+def extract_addon_metadata(addon_path, type)
+  readme = addon_path / "readme.md"
+  return nil unless readme.exist?
+
+  front_matter = extract_front_matter(readme)
+
+  title = front_matter[:label] if front_matter.is_a?(Hash)
+  return nil unless title && !title.include?("1.x")
+
+  path = "#{type}/#{addon_path.basename}/"
+  children = front_matter[:children]
+
+  [path, title, children]
+end
+
+def extract_front_matter(pathname)
+  content = pathname.read
+
+  match = content.match(/\A---(?<yaml>.*?)^---/m)
+  return nil unless match
+
+  begin
+    YAML.safe_load(match[:yaml], symbolize_names: true)
+  rescue Psych::SyntaxError => e
+    puts "⚠️  YAML syntax error in front-matter of #{pathname} - skipping front-matter extraction: #{e.message}"
+    nil
+  end
+rescue Errno::ENOENT
+  nil
+end
+
+def create_addon_entry(path, title, children)
+  if children && !children.empty?
+    {
+      path: "/addons/#{path}",
+      title:,
+      children: [[path, "Overview"]] + normalize_child_path(path, children)
+    }
+  else
+    [path, title]
+  end
+end
+
+def path_exists?(path)
+  ADDONS_DST.join("#{path}.md").exist?
+end
+
+def normalize_path(prefix, path)
+  (path.start_with?("/") || path.start_with?(prefix)) ? path : "#{prefix}#{path}"
+end
+
+#
+# Loop through the children and normalize their paths, ensuring they exist in the destination.
+#
+# The children define their path relative to itself, e.g. "doc/filename".
+# We need to prepend the prefix to this path so vuepress can find it.
+# The children can be a mix of strings, arrays, and hashes, so we need to handle each case accordingly.
+#
+# Case 1:
+#   children:
+#     - "doc/filename"
+#
+# Case 2:
+#   children:
+#     - ["doc/filename", "Title"]
+#
+# Case 3 (mixed - nested children is possible but untested!):
+#   children:
+#     - "doc/filename"
+#     - ["doc/filename", "Title"]
+#     - path: "doc/filename"
+#       title: "Title"
+#
+def normalize_child_path(prefix, item)
+  case item
+  when Array
+    # If it is a flat [path, title] pair, treat it as a single node
+    if item.size == 2 && item.all? { |el| el.is_a?(String) }
+      process_single_node(prefix, item[0], item[1])
+    else
+      # Otherwise, it is a list of children to recursively map and clean
+      item.map { |child| normalize_child_path(prefix, child) }.compact
+    end
+  when String
+    process_single_node(prefix, item)
+  when Hash
+    process_hash_node(prefix, item)
+  else
+    item
+  end
+end
+
+def process_single_node(prefix, path, title = nil)
+  normalized_path = normalize_path(prefix, path)
+
+  if path_exists?(normalized_path)
+    title ? [normalized_path, title] : normalized_path
+  else
+    puts "⚠️  Skipping #{normalized_path} as the file does not exist"
+    nil
+  end
+end
+
+def process_hash_node(prefix, node)
+  updated = node.dup
+
+  if updated[:path]
+    normalized_path = normalize_path(prefix, updated[:path])
+    return nil unless path_exists?(normalized_path)
+
+    updated[:path] = normalized_path
+  end
+
+  updated[:children] = normalize_child_path(prefix, updated[:children]).compact if updated[:children]
+
+  updated
 end

--- a/scripts/prepare-website.rb
+++ b/scripts/prepare-website.rb
@@ -38,6 +38,10 @@ OptionParser.new do |opts|
   opts.on("--verbose", "Run the script with verbose output") do
     $verbose = true
   end
+
+  opts.on("--prettify", "Run Prettier to format the generated JS files") do
+    options[:prettify] = true
+  end
 end.parse!
 
 puts "➡️ Generating docs from openhab-docs branch '#{DOCS_REPO_BRANCH}'"
@@ -77,19 +81,19 @@ LOGOS_DST.rmtree if LOGOS_DST.exist?
 FileUtils.cp_r(DOCS_SRC / "images/addons", LOGOS_DST) if Dir.exist?(DOCS_SRC / "images/addons")
 
 puts "➡️ Copying pre-processed docs from openhab-docs"
-FileUtils.cp_r(DOCS_SRC.join("docs/."), DOCS_DST) # use join to fix vscode highlighting issue
+FileUtils.cp_r(DOCS_SRC.join("docs/."), DOCS_DST)
 
 unless options[:pull_request]
   ADDONS_DST.mkpath
   # Map pre-processed addon folders to their correct destination names
-  FileUtils.cp_r(DOCS_SRC / "addons/automation/.", ADDONS_DST / "automation")
-  FileUtils.cp_r(DOCS_SRC / "addons/binding/.", ADDONS_DST / "bindings")
-  FileUtils.cp_r(DOCS_SRC / "addons/integration/.", ADDONS_DST / "integrations")
-  FileUtils.cp_r(DOCS_SRC / "addons/persistence/.", ADDONS_DST / "persistence")
-  FileUtils.cp_r(DOCS_SRC / "addons/transformation/.", ADDONS_DST / "transformations")
-  FileUtils.cp_r(DOCS_SRC / "addons/ui/.", ADDONS_DST / "ui")
-  FileUtils.rm_rf(ADDONS_DST.join("ui/org.openhab.ui")) # use join to fix vscode highlighting issue
-  FileUtils.cp_r(DOCS_SRC / "addons/voice/.", ADDONS_DST / "voice")
+  FileUtils.cp_r(DOCS_SRC.join("addons/automation/."), ADDONS_DST.join("automation"))
+  FileUtils.cp_r(DOCS_SRC.join("addons/binding/."), ADDONS_DST.join("bindings"))
+  FileUtils.cp_r(DOCS_SRC.join("addons/integration/."), ADDONS_DST.join("integrations"))
+  FileUtils.cp_r(DOCS_SRC.join("addons/persistence/."), ADDONS_DST.join("persistence"))
+  FileUtils.cp_r(DOCS_SRC.join("addons/transformation/."), ADDONS_DST.join("transformations"))
+  FileUtils.cp_r(DOCS_SRC.join("addons/ui/."), ADDONS_DST.join("ui"))
+  FileUtils.rm_rf(ADDONS_DST.join("ui/org.openhab.ui"))
+  FileUtils.cp_r(DOCS_SRC.join("addons/voice/."), ADDONS_DST.join("voice"))
 end
 
 # Write arrays of addons by type to include in VuePress config.js
@@ -111,8 +115,11 @@ puts "➡️ Writing add-ons arrays to files for sidebar navigation"
   File.write(dest_file, "module.exports = #{JSON.generate(module_exports)}")
 end
 
-puts "➡️ Formatting the generated sidebar navigation files"
-system("npx prettier --write '.vuepress/addons-*.js' --print-width 300") # Format the generated JS files
+if options[:prettify]
+  # Make it easier to read the generated JS files during development
+  puts "➡️ Formatting the generated sidebar navigation files"
+  system("npx prettier --write '.vuepress/addons-*.js' --print-width 300") # Format the generated JS files
+end
 
 # Clean-Ups required for repeated local build
 verbose "🧹 Cleaning existing JavaDoc ..."

--- a/scripts/prepare-website.rb
+++ b/scripts/prepare-website.rb
@@ -8,7 +8,6 @@ require "pathname"
 require "uri"
 require "open-uri"
 require "json"
-require "open3"
 
 require_relative "lib/website_utils"
 

--- a/scripts/prepare-website.rb
+++ b/scripts/prepare-website.rb
@@ -8,6 +8,7 @@ require "pathname"
 require "uri"
 require "open-uri"
 require "json"
+require "open3"
 
 require_relative "lib/website_utils"
 
@@ -73,12 +74,10 @@ clean_ignored_files(ADDONS_DST)
 
 puts "➡️ Migrating logos"
 LOGOS_DST.rmtree if LOGOS_DST.exist?
-if Dir.exist?(DOCS_SRC / "images/addons")
-  FileUtils.cp_r(DOCS_SRC / "images/addons", LOGOS_DST)
-end
+FileUtils.cp_r(DOCS_SRC / "images/addons", LOGOS_DST) if Dir.exist?(DOCS_SRC / "images/addons")
 
 puts "➡️ Copying pre-processed docs from openhab-docs"
-FileUtils.cp_r(DOCS_SRC / "docs/.", DOCS_DST)
+FileUtils.cp_r(DOCS_SRC.join("docs/."), DOCS_DST) # use join to fix vscode highlighting issue
 
 unless options[:pull_request]
   ADDONS_DST.mkpath
@@ -89,7 +88,7 @@ unless options[:pull_request]
   FileUtils.cp_r(DOCS_SRC / "addons/persistence/.", ADDONS_DST / "persistence")
   FileUtils.cp_r(DOCS_SRC / "addons/transformation/.", ADDONS_DST / "transformations")
   FileUtils.cp_r(DOCS_SRC / "addons/ui/.", ADDONS_DST / "ui")
-  FileUtils.rm_rf(ADDONS_DST / "ui/org.openhab.ui")
+  FileUtils.rm_rf(ADDONS_DST.join("ui/org.openhab.ui")) # use join to fix vscode highlighting issue
   FileUtils.cp_r(DOCS_SRC / "addons/voice/.", ADDONS_DST / "voice")
 end
 
@@ -101,34 +100,19 @@ puts "➡️ Writing add-ons arrays to files for sidebar navigation"
   module_exports = []
   if type_dir.directory?
     # Find all subdirectories excluding hidden ones
-    module_exports = type_dir.children.select(&:directory?).filter_map do |addon_path|
-      readme = addon_path / "readme.md"
-      next unless readme.exist?
-
-      # Find the first line starting with "label: "
-      label_line = readme.each_line.find { |line| line.start_with?("label: ") }
-      next unless label_line
-
-      title = label_line.delete_prefix("label: ").strip
-      next if title.include?("1.x")
-
-      path = "#{type}/#{addon_path.basename}/"
-
-      # Return the pair for the module_exports array
-      [path, title]
-    end
+    module_exports = type_dir.children.select(&:directory?)
+                             .filter_map { |dir| extract_addon_metadata(dir, type) }
+                             .sort_by { |_, title, _| title.downcase }
+                             .map { |path, title, children| create_addon_entry(path, title, children) }
   end
-
-  formatted_exports = module_exports.map { |path, title| "  [ '#{path}', '#{title}' ]" }.join(",\n")
 
   dest_file = ".vuepress/addons-#{type}.js"
   puts "   ↪️ Writing #{dest_file} (#{module_exports.size} items)"
-  File.write(dest_file, <<~JS)
-    module.exports = [
-    #{formatted_exports}
-    ]
-  JS
+  File.write(dest_file, "module.exports = #{JSON.generate(module_exports)}")
 end
+
+puts "➡️ Formatting the generated sidebar navigation files"
+system("npx prettier --write '.vuepress/addons-*.js' --print-width 300") # Format the generated JS files
 
 # Clean-Ups required for repeated local build
 verbose "🧹 Cleaning existing JavaDoc ..."

--- a/scripts/prepare-website.rb
+++ b/scripts/prepare-website.rb
@@ -102,7 +102,6 @@ puts "➡️ Writing add-ons arrays to files for sidebar navigation"
 
   module_exports = []
   if type_dir.directory?
-    # Find all subdirectories excluding hidden ones
     module_exports = type_dir.children.select(&:directory?)
                              .filter_map { |dir| extract_addon_metadata(dir, type) }
                              .sort_by { |_, title, _| title.downcase }


### PR DESCRIPTION
The main addon README.md front-matter can specify sub-documents to be added into the side navigation bar. Example:

```
---
children:
  - ["doc/basics", "YAML Basics"]
  - ["doc/variables", "Variables"]
  - ["doc/conditionals", "Conditionals"]
  - ["doc/include", "Include"]
  - ["doc/templates", "Templates"]
  - ["doc/packages", "Packages"]
  - ["doc/anchors", "Anchors and Aliases"]
  - ["doc/merge-keys", "Merge Keys"]
---
```

This will result in a sidebar navigation entry like this:

```js
  {
    path: "/addons/integrations/yamlcomposer/",
    title: "YAML Composer",
    children: [
      ["integrations/yamlcomposer/", "Overview"],
      ["integrations/yamlcomposer/doc/basics", "YAML Basics"],
      ["integrations/yamlcomposer/doc/variables", "Variables"],
      ["integrations/yamlcomposer/doc/conditionals", "Conditionals"],
      ["integrations/yamlcomposer/doc/include", "Include"],
      ["integrations/yamlcomposer/doc/templates", "Templates"],
      ["integrations/yamlcomposer/doc/packages", "Packages"],
      ["integrations/yamlcomposer/doc/anchors", "Anchors and Aliases"],
      ["integrations/yamlcomposer/doc/merge-keys", "Merge Keys"],
    ],
  },
  ```

Example implementation of this feature: openhab/openhab-addons#21070